### PR TITLE
Update abstract-xhr.js

### DIFF
--- a/lib/transport/browser/abstract-xhr.js
+++ b/lib/transport/browser/abstract-xhr.js
@@ -30,7 +30,9 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
   function setOAuthHeader() {
     if (localStorage.getItem('OAUTH_TOKEN')) {
       const auth = JSON.parse(localStorage.getItem('OAUTH_TOKEN'));
+      const csrf = JSON.parse(localStorage.getItem('XSRF-TOKEN'));
       self.xhr.setRequestHeader('Authorization', 'Bearer ' + auth.access_token);
+      self.xhr.setRequestHeader(csrf.name, csrf.token);
     }
   }
 


### PR DESCRIPTION
In case to send CSRF token we need to add it as well in headers of each request.  Tested on loacl and work fine.