### PR TITLE
Library patch to allow only WebSocket protocol calls

### DIFF
--- a/lib/transport-list.js
+++ b/lib/transport-list.js
@@ -3,16 +3,16 @@
 module.exports = [
   // streaming transports
   require('./transport/websocket')
-, require('./transport/xhr-streaming')
-, require('./transport/xdr-streaming')
-, require('./transport/eventsource')
-, require('./transport/lib/iframe-wrap')(require('./transport/eventsource'))
+// , require('./transport/xhr-streaming')
+// , require('./transport/xdr-streaming')
+// , require('./transport/eventsource')
+// , require('./transport/lib/iframe-wrap')(require('./transport/eventsource'))
 
   // polling transports
-, require('./transport/htmlfile')
-, require('./transport/lib/iframe-wrap')(require('./transport/htmlfile'))
-, require('./transport/xhr-polling')
-, require('./transport/xdr-polling')
-, require('./transport/lib/iframe-wrap')(require('./transport/xhr-polling'))
-, require('./transport/jsonp-polling')
+// , require('./transport/htmlfile')
+// , require('./transport/lib/iframe-wrap')(require('./transport/htmlfile'))
+// , require('./transport/xhr-polling')
+// , require('./transport/xdr-polling')
+// , require('./transport/lib/iframe-wrap')(require('./transport/xhr-polling'))
+// , require('./transport/jsonp-polling')
 ];


### PR DESCRIPTION
Disabled other alternative transport ways in order to make only websocket requests and debug effectively