### PR TITLE
Generate uid and persist it in the handshake / websocket calls

### DIFF
--- a/lib/transport/browser/abstract-xhr.js
+++ b/lib/transport/browser/abstract-xhr.js
@@ -2,6 +2,7 @@
 
 var EventEmitter = require('events').EventEmitter
   , inherits = require('inherits')
+  , uuid = require('uuid').v4
   , utils = require('../../utils/event')
   , urlUtils = require('../../utils/url')
   , XHR = global.XMLHttpRequest
@@ -55,6 +56,10 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
   // several browsers cache POSTs
   url = urlUtils.addQuery(url, 't=' + (+new Date()));
 
+  const uidToken = uuid();
+  sessionStorage.setItem('X-UID-TOKEN', uidToken);
+  url = urlUtils.addQuery(url, 'uid=' + uidToken);
+
   // Explorer tends to keep connection open, even after the
   // tab gets closed: http://bugs.jquery.com/ticket/5280
   this.unloadRef = utils.unloadAdd(function() {
@@ -97,10 +102,6 @@ AbstractXHRObject.prototype._start = function(method, url, payload, opts) {
     if (self.xhr) {
       var x = self.xhr;
       var text, status;
-      try {
-        const uidToken = JSON.parse(x.getResponseHeader('X-UID-TOKEN'));
-        sessionStorage.setItem('X-UID-TOKEN', uidToken);
-      } catch {}
       debug('readyState', x.readyState);
       switch (x.readyState) {
       case 3:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "faye-websocket": "~0.11.1",
     "inherits": "^2.0.3",
     "json3": "^3.3.2",
-    "url-parse": "^1.4.7"
+    "url-parse": "^1.4.7",
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "browserify": "^16.2.3",


### PR DESCRIPTION
Adjusted library to generate uid based on new dependency and persist it in the handshake / websocket calls